### PR TITLE
sidekiqでリポジトリのクロールをスケジューリングする

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+milkode/
+.milkode/
+gitlab/
+.ssh

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ milkode/
 .milkode/
 gitlab/
 .ssh
+sidekiq

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 milkode/
 .milkode/
 gitlab/
+.ssh

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ milkode/
 .milkode/
 gitlab/
 .ssh
+sidekiq

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,11 @@ WORKDIR /products
 
 ADD Gemfile /products/Gemfile
 ADD Gemfile.lock /products/Gemfile.lock
+ADD run.sh /products/run.sh
+ADD config.ru /products/config.ru
+ADD config.yml /products/config.yml
+ADD repository.yml /products/repository.yml
+ADD sidekiq.rb /products/sidekiq.rb
 
 # ENV MILKODE_DEFAULT_DIR=/products
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,8 @@ source "https://rubygems.org"
 gem "milkode"
 
 gem "pry"
+
+gem 'sidekiq'
+gem 'sinatra'
+gem 'redis'
+gem 'redis-namespace'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,8 @@ GEM
     archive-zip (0.8.0)
       io-like (~> 0.3.0)
     coderay (1.1.0)
+    concurrent-ruby (1.0.0)
+    connection_pool (2.2.0)
     daemons (1.2.3)
     eventmachine (1.0.8)
     gqtp (1.0.6)
@@ -45,6 +47,9 @@ GEM
     rack (1.6.4)
     rack-protection (1.5.3)
       rack
+    redis (3.2.2)
+    redis-namespace (1.5.2)
+      redis (~> 3.0, >= 3.0.4)
     rroonga (5.0.9)
       archive-zip
       groonga-client (>= 0.0.3)
@@ -53,6 +58,10 @@ GEM
     sane (0.25.8)
       os (~> 0)
     sass (3.4.20)
+    sidekiq (4.0.2)
+      concurrent-ruby (~> 1.0)
+      connection_pool (~> 2.2, >= 2.2.0)
+      redis (~> 3.2, >= 3.2.1)
     sinatra (1.4.6)
       rack (~> 1.4)
       rack-protection (~> 1.4)
@@ -75,6 +84,10 @@ PLATFORMS
 DEPENDENCIES
   milkode
   pry
+  redis
+  redis-namespace
+  sidekiq
+  sinatra
 
 BUNDLED WITH
    1.11.2

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 * milkodeの起動
 
-docker-compose up -d
+$> docker-compose up -d
 
 * sidekiqの起動
 
-sidekiq -r ./sidekiq.rb -C ./config.yml
+docker exec -it [milkode_main_container_id] /bin/bash
+$> sidekiq -r ./sidekiq.rb -C ./config.yml
 
+* sidekiqのweb UIの起動
+
+docker exec -it [milkode_main_container_id] /bin/bash
+$> rackup -p 9000 -o 0.0.0.0

--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@
 
 docker-compose up -d
 
+* sidekiqの起動
+
+sidekiq -r ./sidekiq.rb -C ./config.yml
+

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,12 @@
+require 'sidekiq'
+
+@redis_url = 'redis://redis/0/'
+
+Sidekiq.configure_client do |config|
+  config.redis = { :url => @redis_url, :size => 1, :namespace => 'foo' }
+end
+
+
+require 'sidekiq/web'
+run Sidekiq::Web
+

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,25 @@
+# Sample configuration file for Sidekiq.
+# Options here can still be overridden by cmd line args.
+# Place this file at config/sidekiq.yml and Sidekiq will
+# pick it up automatically.
+---
+:verbose: false
+:concurrency: 10
+
+# Set timeout to 8 on Heroku, longer if you manage your own systems.
+:timeout: 30
+
+# Sidekiq will run this file through ERB when reading it so you can
+# even put in dynamic logic, like a host-specific queue.
+# http://www.mikeperham.com/2013/11/13/advanced-sidekiq-host-specific-queues/
+:queues:
+  - critical
+  - default
+  - <%= `hostname`.strip %>
+  - low
+
+# you can override concurrency based on environment
+production:
+  :concurrency: 25
+staging:
+  :concurrency: 15

--- a/config.yml
+++ b/config.yml
@@ -14,7 +14,7 @@
 # http://www.mikeperham.com/2013/11/13/advanced-sidekiq-host-specific-queues/
 :queues:
   - critical
-  - default
+  - [default, 1]
   - <%= `hostname`.strip %>
   - low
 

--- a/config.yml
+++ b/config.yml
@@ -4,7 +4,7 @@
 # pick it up automatically.
 ---
 :verbose: false
-:concurrency: 10
+:concurrency: 2
 
 # Set timeout to 8 on Heroku, longer if you manage your own systems.
 :timeout: 30

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ main:
    - .:/products
 
   ports:
+    - "9000:9000"
     - "9292:9292"
 
   links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,5 +11,13 @@ main:
   ports:
     - "9292:9292"
 
+  links:
+    - "redis:redis"
+
   command: bundle exec milk web -n -o 0.0.0.0
 
+redis:
+  image: redis
+
+  ports:
+    - "6379:6379"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ main:
   links:
     - "redis:redis"
 
-  command: bundle exec milk web -n -o 0.0.0.0
+  command: bundle exec /products/run.sh
 
 redis:
   image: redis

--- a/repository.yml
+++ b/repository.yml
@@ -1,0 +1,6 @@
+#
+# repositories:
+#   - git@github.com:gendosu/test.git
+#
+repositories:
+

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# startup milk web
+milk web -n -o 0.0.0.0 &
+
+# startup sidekiq
+sidekiq -r ./sidekiq.rb -C ./config.yml -L sidekiq.log -d
+
+# startup sidekiq web ui
+rackup -p 9000 -o 0.0.0.0 -D

--- a/run.sh
+++ b/run.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-# startup milk web
-milk web -n -o 0.0.0.0 &
-
 # startup sidekiq
 sidekiq -r ./sidekiq.rb -C ./config.yml -L sidekiq.log -d
 
 # startup sidekiq web ui
 rackup -p 9000 -o 0.0.0.0 -D
+
+# startup milk web
+milk web -n -o 0.0.0.0

--- a/sidekiq.rb
+++ b/sidekiq.rb
@@ -38,12 +38,6 @@ end
 
 Sidekiq::Web.app_url = '/'
 
-class EmptyWorker
-  include Sidekiq::Worker
-
-  def perform
-  end
-end
 
 class CrawlWorker
   include Sidekiq::Worker
@@ -108,14 +102,5 @@ class CrawlListWorker
       p "add: #{repo}, #{index}"
       CrawlWorker.perform_in(index+ 1, repo)
     end
-  end
-end
-
-class TimedWorker
-  include Sidekiq::Worker
-
-  def perform(start)
-    now = Time.now.to_f
-    puts "Latency: #{now - start} sec"
   end
 end

--- a/sidekiq.rb
+++ b/sidekiq.rb
@@ -86,7 +86,11 @@ class CrawlListWorker
   include Sidekiq::Worker
 
   def perform()
-    redis_url = 'redis://redis/0/'
+    repositories_yml = YAML.load_file('repository.yml')
+
+    repositories = repositories_yml['repositories']
+
+    # redis_url = 'redis://redis/0/'
     # リポジトリをクロールする
     # redisにクロールするリポジトリ一覧持つかな。。
     #   リスト追加
@@ -96,9 +100,9 @@ class CrawlListWorker
     #   キュー削除
     #     queues = Sidekiq::Queue.new('foo')
     #     queues.clear
-    redis = Redis.new(:url => redis_url)
+    # redis = Redis.new(:url => redis_url)
 
-    repositories = redis.lrange('crawl_list', 0, -1)
+    # repositories = redis.lrange('crawl_list', 0, -1)
 
     repositories.each_with_index do |repo, index|
       p "add: #{repo}, #{index}"

--- a/sidekiq.rb
+++ b/sidekiq.rb
@@ -1,0 +1,37 @@
+Sidekiq.configure_client do |config|
+  config.redis = { :url => 'redis://redis/0/', :size => 2, :namespace => 'foo' }
+end
+Sidekiq.configure_server do |config|
+  config.redis = { :url => 'redis://redis/0/', :namespace => 'foo' }
+  config.on(:startup) { }
+  config.on(:quiet) { }
+  config.on(:shutdown) do
+    #result = RubyProf.stop
+
+    ## Write the results to a file
+    ## Requires railsexpress patched MRI build
+    # brew install qcachegrind
+    #File.open("callgrind.profile", "w") do |f|
+      #RubyProf::CallTreePrinter.new(result).print(f, :min_percent => 1)
+    #end
+  end
+end
+
+require 'sidekiq/web'
+Sidekiq::Web.app_url = '/'
+
+class EmptyWorker
+  include Sidekiq::Worker
+
+  def perform
+  end
+end
+
+class TimedWorker
+  include Sidekiq::Worker
+
+  def perform(start)
+    now = Time.now.to_f
+    puts "Latency: #{now - start} sec"
+  end
+end

--- a/sidekiq.rb
+++ b/sidekiq.rb
@@ -77,6 +77,7 @@ class CrawlWorker
       end
     end
 
+    CrawlWorker.perform_in( 60 * 60 * 24, repository)
   end
 end
 

--- a/sidekiq.rb
+++ b/sidekiq.rb
@@ -71,6 +71,7 @@ class CrawlWorker
       repository_name = (uri.path + (uri.query || '')).gsub(/^\//, "").gsub(/\//, "_")
     end
 
+    p "run milk add --name=#{repository_name} #{repository}"
     Open3.popen3("milk add --name=#{repository_name} #{repository}") do |stdin, stdout, stderr, wait_thr|
       if stdout.read.include?('already exist')
         system("milk update #{repository_name}")
@@ -100,6 +101,7 @@ class CrawlListWorker
     repositories = redis.lrange('crawl_list', 0, -1)
 
     repositories.each_with_index do |repo, index|
+      p "add: #{repo}, #{index}"
       CrawlWorker.perform_in(index+ 1, repo)
     end
   end

--- a/sidekiq.rb
+++ b/sidekiq.rb
@@ -10,6 +10,7 @@ include Milkode::Util
 Sidekiq.configure_client do |config|
   config.redis = { :url => @redis_url, :size => 2, :namespace => 'foo' }
 end
+
 Sidekiq.configure_server do |config|
   config.redis = { :url => @redis_url, :namespace => 'foo' }
 

--- a/sidekiq.rb
+++ b/sidekiq.rb
@@ -98,8 +98,8 @@ class CrawlListWorker
 
     repositories = redis.lrange('crawl_list', 0, -1)
 
-    repositories.each do |repo|
-      CrawlWorker.perform_async(repo)
+    repositories.each_with_index do |repo, index|
+      CrawlWorker.perform_in(index+ 1, repo)
     end
   end
 end

--- a/sidekiq.rb
+++ b/sidekiq.rb
@@ -63,7 +63,7 @@ class CrawlWorker
     redis.lpush('crawl_list', repository)
 
     if(git_url?(repository))
-      repository_name = repository.gsub(/^[^:]*:/, '').gsub(/^\//, "").gsub(/\//, "_")
+      repository_name = repository.gsub(/^[^:]*:/, '').gsub(/^\//, "").gsub(/\//, "_").gsub(/\.git$/, "")
     else
       uri = URI.parse(repository)
       repository_name = (uri.path + (uri.query || '')).gsub(/^\//, "").gsub(/\//, "_")

--- a/sidekiq.rb
+++ b/sidekiq.rb
@@ -17,6 +17,8 @@ Sidekiq.configure_server do |config|
   config.on(:startup) do
     queue = Sidekiq::Queue.new
     queue.clear
+    ss = Sidekiq::ScheduledSet.new
+    ss.clear
 
     CrawlListWorker.perform_async
   end

--- a/sidekiq.rb
+++ b/sidekiq.rb
@@ -27,6 +27,22 @@ class EmptyWorker
   end
 end
 
+class CrawlWorker
+  include Sidekiq::Worker
+
+  def perform
+    # リポジトリをクロールする
+  end
+end
+
+class CrawlListWorker
+  include Sidekiq::Worker
+
+  def perform
+    # クロールするリポジトリの一覧を更新する
+  end
+end
+
 class TimedWorker
   include Sidekiq::Worker
 

--- a/sidekiq.rb
+++ b/sidekiq.rb
@@ -15,7 +15,6 @@ Sidekiq.configure_server do |config|
   config.redis = { :url => @redis_url, :namespace => 'foo' }
 
   config.on(:startup) do
-    p 'clear queue'
     queue = Sidekiq::Queue.new
     queue.clear
 
@@ -74,10 +73,8 @@ class CrawlWorker
       if stdout.read.include?('already exist')
         system("milk update #{repository_name}")
       end
-      p stderr.read
     end
 
-    p redis.lrange('crawl_list', 0, -1)
   end
 end
 
@@ -100,7 +97,6 @@ class CrawlListWorker
     repositories = redis.lrange('crawl_list', 0, -1)
 
     repositories.each do |repo|
-      p repo
       CrawlWorker.perform_async(repo)
     end
   end

--- a/sidekiq.rb
+++ b/sidekiq.rb
@@ -82,7 +82,7 @@ class CrawlListWorker
   def perform()
     repositories_yml = YAML.load_file('repository.yml')
 
-    repositories = repositories_yml['repositories']
+    repositories = repositories_yml['repositories'] || []
 
     # redis_url = 'redis://redis/0/'
     # リポジトリをクロールする


### PR DESCRIPTION
### TODO
- [x] redisを入れる (sidekiq用)
- [x] sidekiqを入れる
- [x] sidekiqの起動用の設定とスクリプト準備
- [x] sidekiqのワーカー作成
- [ ] sidekiqにエンキューするフローを検討
- [ ] リファクタリング
### 検討事項

sidekiq起動時に、現在登録されているキューを一旦全部削除
redisに別途登録されているリポジトリの一覧からキューを自動追加
リポジトリクロールのキューの実行が正常に終了したら
次回(1日後？)実行用のキューを再登録
